### PR TITLE
Index based parsing

### DIFF
--- a/Examples/CaseConverter.test.ts
+++ b/Examples/CaseConverter.test.ts
@@ -21,9 +21,9 @@ describe("parses string casing", () => {
             const result = detectCasing.parse(input);
             switch (result.variant) {
                 case Result.Variant.Ok:
-                    const [casing, rem] = result.value;
+                    const [casing, i] = result.value;
                     expect(casing).toBe(expected);
-                    expect(rem).toBe(remaining);
+                    expect(input.slice(i)).toBe(remaining);
                     break;
 
                 default:

--- a/Examples/RegularLanguages.test.ts
+++ b/Examples/RegularLanguages.test.ts
@@ -43,8 +43,14 @@ describe("simple regular expression /a(b|c)d*/", () => {
     });
 
     const errCases: Array<[string, string]> = [
-        ["bd", 'Expected "a" but got "b" instead'],
-        ["ad", 'Expected "c" but got "d" instead'],
+        [
+            "bd",
+            'Error at (line: 1, column: 1)\nExpected "a" but got "b" instead\n\nbd\n^',
+        ],
+        [
+            "ad",
+            'Error at (line: 1, column: 2)\nExpected "c" but got "d" instead\n\nad\n ^',
+        ],
     ];
 
     test.each(errCases)("Does not match '%s'", (source, errMessage) => {
@@ -127,8 +133,8 @@ describe("date parser", () => {
         sequence(
             yearParser,
             oneOf(
-                sequence(exact("-"), monthParser, exact("-"), dayParser),
                 sequence(exact("/"), monthParser, exact("/"), dayParser),
+                sequence(exact("-"), monthParser, exact("-"), dayParser),
             ),
         ),
     );
@@ -151,14 +157,21 @@ describe("date parser", () => {
     });
 
     const errCases: Array<[string, string]> = [
-        ["2021-03/26", 'Expected "-" but got "/" instead'],
-        ["2021/03-26", 'Expected "/" but got "-" instead'],
+        [
+            "2021-03/26",
+            'Error at (line: 1, column: 8)\nExpected "-" but got "/" instead\n\n2021-03/26\n       ^',
+        ],
+        [
+            "2021/03-26",
+            'Error at (line: 1, column: 5)\nExpected "-" but got "/" instead\n\n2021/03-26\n    ^',
+        ],
     ];
 
-    test.each(errCases)("Does not parse date in '%s'", (source) => {
+    test.each(errCases)("Does not parse date in '%s'", (source, errMessage) => {
         const result = dateParser.parse(source);
         switch (result.variant) {
             case Result.Variant.Err:
+                expect(result.error).toBe(errMessage);
                 break;
 
             case Result.Variant.Ok:

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ combinator. Instead, this is a pure [closure](https://whatthefuck.is/closure).
 
 ## [Unreleased]
 
+## Changed
+- Updates to index-based system
+
 ## [2.2.0] : 2021-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ const dateParser = map(
     sequence(
         yearParser,
         oneOf(
-            sequence(exact("-"), monthParser, exact("-"), dayParser),
             sequence(exact("/"), monthParser, exact("/"), dayParser),
+            sequence(exact("-"), monthParser, exact("-"), dayParser),
         ),
     ),
 );
@@ -162,18 +162,23 @@ const dateParser = map(
     sequence(
         yearParser,
         oneOf(
-            monthDayWithSeparator(exact("-"), monthParser, dayParser),
-            monthDayWithSeparator(exact("/"), monthParser, dayParser),
             monthDayWithSeparator(exact(":"), monthParser, dayParser),
+            monthDayWithSeparator(exact("/"), monthParser, dayParser),
+            monthDayWithSeparator(exact("-"), monthParser, dayParser),
         ),
     ),
 );
 ```
 
 Finally, the best part is that when a match fails, instead of just `null`, we
-actually get an error message like
-```
-'Expected "-" but got "/" instead'
+can get nicer error messages.
+```js
+dateParser.parse("2021/03-27");
+// Error at (line: 1, column: 8)
+// Expected "-" but got "/" instead
+// 
+// 2021-03/26
+//        ^
 ```
 
 # Terminology
@@ -222,6 +227,7 @@ combinator. Instead, this is a pure [closure](https://whatthefuck.is/closure).
 
 ## Changed
 - Updates to index-based system
+- Adds better error messages
 
 ## [2.2.0] : 2021-04-02
 

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -24,7 +24,7 @@ describe("Individual Parser functions", () => {
             [
                 "goodbye",
                 "hello world",
-                'Expected "goodbye" but got "hello w" instead',
+                'Error at (line: 1, column: 1)\nExpected "goodbye" but got "hello w" instead\n\nhello worl\n^',
             ],
         ];
 
@@ -187,13 +187,13 @@ describe("Individual Parser functions", () => {
             const errCases: Array<[string, string, string]> = [
                 [
                     "",
-                    'Expected a digit but got "" instead',
-                    'Expected digits but got "" instead',
+                    'Error at (line: 1, column: 1)\nExpected a digit but got "" instead\n\n\n^',
+                    'Error at (line: 1, column: 1)\nExpected digits but got "" instead\n\n\n^',
                 ],
                 [
                     "abcde",
-                    'Expected a digit but got "a" instead',
-                    'Expected digits but got "a" instead',
+                    'Error at (line: 1, column: 1)\nExpected a digit but got "a" instead\n\nabcde\n^',
+                    'Error at (line: 1, column: 1)\nExpected digits but got "a" instead\n\nabcde\n^',
                 ],
             ];
 
@@ -215,13 +215,13 @@ describe("Individual Parser functions", () => {
             const errCases: Array<[string, string, string]> = [
                 [
                     "",
-                    'Expected a character but got "" instead',
-                    'Expected characters but got "" instead',
+                    'Error at (line: 1, column: 1)\nExpected a character but got "" instead\n\n\n^',
+                    'Error at (line: 1, column: 1)\nExpected characters but got "" instead\n\n\n^',
                 ],
                 [
                     "12345",
-                    'Expected a character but got "1" instead',
-                    'Expected characters but got "1" instead',
+                    'Error at (line: 1, column: 1)\nExpected a character but got "1" instead\n\n12345\n^',
+                    'Error at (line: 1, column: 1)\nExpected characters but got "1" instead\n\n12345\n^',
                 ],
             ];
 
@@ -243,13 +243,13 @@ describe("Individual Parser functions", () => {
             const errCases: Array<[string, string, string]> = [
                 [
                     "",
-                    'Expected an upper case character but got "" instead',
-                    'Expected upper case characters but got "" instead',
+                    'Error at (line: 1, column: 1)\nExpected an upper case character but got "" instead\n\n\n^',
+                    'Error at (line: 1, column: 1)\nExpected upper case characters but got "" instead\n\n\n^',
                 ],
                 [
                     "12345",
-                    'Expected an upper case character but got "1" instead',
-                    'Expected upper case characters but got "1" instead',
+                    'Error at (line: 1, column: 1)\nExpected an upper case character but got "1" instead\n\n12345\n^',
+                    'Error at (line: 1, column: 1)\nExpected upper case characters but got "1" instead\n\n12345\n^',
                 ],
             ];
 
@@ -272,13 +272,13 @@ describe("Individual Parser functions", () => {
             const errCases: Array<[string, string, string]> = [
                 [
                     "",
-                    'Expected a lower case character but got "" instead',
-                    'Expected lower case characters but got "" instead',
+                    'Error at (line: 1, column: 1)\nExpected a lower case character but got "" instead\n\n\n^',
+                    'Error at (line: 1, column: 1)\nExpected lower case characters but got "" instead\n\n\n^',
                 ],
                 [
                     "12345",
-                    'Expected a lower case character but got "1" instead',
-                    'Expected lower case characters but got "1" instead',
+                    'Error at (line: 1, column: 1)\nExpected a lower case character but got "1" instead\n\n12345\n^',
+                    'Error at (line: 1, column: 1)\nExpected lower case characters but got "1" instead\n\n12345\n^',
                 ],
             ];
 
@@ -302,13 +302,13 @@ describe("Individual Parser functions", () => {
             const errCases: Array<[string, string, string]> = [
                 [
                     "",
-                    'Expected an alpha numeric character but got "" instead',
-                    'Expected alpha numeric characters but got "" instead',
+                    'Error at (line: 1, column: 1)\nExpected an alpha numeric character but got "" instead\n\n\n^',
+                    'Error at (line: 1, column: 1)\nExpected alpha numeric characters but got "" instead\n\n\n^',
                 ],
                 [
                     "$100",
-                    'Expected an alpha numeric character but got "$" instead',
-                    'Expected alpha numeric characters but got "$" instead',
+                    'Error at (line: 1, column: 1)\nExpected an alpha numeric character but got "$" instead\n\n$100\n^',
+                    'Error at (line: 1, column: 1)\nExpected alpha numeric characters but got "$" instead\n\n$100\n^',
                 ],
             ];
 
@@ -378,9 +378,18 @@ describe("Individual Parser functions", () => {
 
             // error messages could be improved
             const errCases: Array<[string, string]> = [
-                ["bob", 'Expected a number but got "b" instead'],
-                [".14159", 'Expected a number but got "." instead'],
-                ["+hello", 'Expected a number but got "+" instead'],
+                [
+                    "bob",
+                    'Error at (line: 1, column: 1)\nExpected a number but got "b" instead\n\nbob\n^',
+                ],
+                [
+                    ".14159",
+                    'Error at (line: 1, column: 1)\nExpected a number but got "." instead\n\n.14159\n^',
+                ],
+                [
+                    "+hello",
+                    'Error at (line: 1, column: 1)\nExpected a number but got "+" instead\n\n+hello\n^',
+                ],
             ];
 
             test.each(errCases)(
@@ -436,7 +445,7 @@ describe("Individual Parser functions", () => {
                 switch (result.variant) {
                     case Result.Variant.Err:
                         expect(result.error).toBe(
-                            'Expected an integer but got "123.1415" instead',
+                            'Error at (line: 1, column: 1)\nExpected an integer but got "123.1415" instead\n\n123.1415 h\n^',
                         );
                         break;
 
@@ -500,7 +509,7 @@ describe("Individual Parser functions", () => {
             switch (result.variant) {
                 case Result.Variant.Err:
                     expect(result.error).toBe(
-                        `Expected "d" but got "f" instead`,
+                        `Error at (line: 1, column: 4)\nExpected "d" but got "f" instead\n\nabcfg\n   ^`,
                     );
                     break;
 
@@ -573,7 +582,11 @@ describe("Individual Parser functions", () => {
         );
 
         const errCases: Array<[string, string, Parser<any>]> = [
-            ["bbbbb", 'Expected "a" but got "b" instead', Parser.exact("a")],
+            [
+                "bbbbb",
+                'Error at (line: 1, column: 1)\nExpected "a" but got "b" instead\n\nbbbbb\n^',
+                Parser.exact("a"),
+            ],
         ];
 
         test.each(errCases)(
@@ -630,7 +643,7 @@ describe("Individual Parser functions", () => {
             switch (result.variant) {
                 case Result.Variant.Err:
                     expect(result.error).toBe(
-                        'Expected "a" but got "b" instead',
+                        'Error at (line: 1, column: 1)\nExpected "a" but got "b" instead\n\nbcd\n^',
                     );
                     break;
 
@@ -691,7 +704,7 @@ describe("Individual Parser functions", () => {
             switch (result.variant) {
                 case Result.Variant.Err:
                     expect(result.error).toBe(
-                        'Expected "c" but got "f" instead',
+                        'Error at (line: 1, column: 1)\nExpected "c" but got "f" instead\n\nf\n^',
                     );
                     break;
 
@@ -855,9 +868,18 @@ describe("Individual Parser functions", () => {
             });
 
             const errCases: Array<[string, string]> = [
-                ["(-blah", 'Expected "blah" but got "-bla" instead'],
-                ["(-ablah", 'Expected "blah" but got "-abl" instead'],
-                ["(-cblah", 'Expected "blah" but got "-cbl" instead'],
+                [
+                    "(-blah",
+                    'Error at (line: 1, column: 2)\nExpected "blah" but got "-bla" instead\n\n(-blah\n ^',
+                ],
+                [
+                    "(-ablah",
+                    'Error at (line: 1, column: 2)\nExpected "blah" but got "-abl" instead\n\n(-ablah\n ^',
+                ],
+                [
+                    "(-cblah",
+                    'Error at (line: 1, column: 2)\nExpected "blah" but got "-cbl" instead\n\n(-cblah\n ^',
+                ],
             ];
 
             test.each(errCases)(
@@ -976,7 +998,10 @@ describe("Individual Parser functions", () => {
             });
 
             const errCases: Array<[string, string]> = [
-                ["abcd", 'Expected "d" but got "c" instead'],
+                [
+                    "abcd",
+                    'Error at (line: 1, column: 3)\nExpected "d" but got "c" instead\n\nabcd\n  ^',
+                ],
             ];
 
             test.each(errCases)("does not parse %s", (source, errMessage) => {

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -57,7 +57,7 @@ describe("Individual Parser functions", () => {
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toBe(value);
-                    expect(result.value[1]).toBe(source);
+                    expect(source.slice(result.value[1])).toBe(source);
                     break;
 
                 case Result.Variant.Err:
@@ -82,7 +82,7 @@ describe("Individual Parser functions", () => {
                 const result = spaces().parse(source);
                 switch (result.variant) {
                     case Result.Variant.Ok:
-                        expect(result.value[1]).toBe(remaining);
+                        expect(source.slice(result.value[1])).toBe(remaining);
                         break;
 
                     case Result.Variant.Err:
@@ -128,7 +128,9 @@ describe("Individual Parser functions", () => {
                     let result = singleParser.parse(source);
                     switch (result.variant) {
                         case Result.Variant.Ok:
-                            expect(result.value[1]).toBe(singleCase);
+                            expect(source.slice(result.value[1])).toBe(
+                                singleCase,
+                            );
                             break;
 
                         case Result.Variant.Err:
@@ -138,7 +140,9 @@ describe("Individual Parser functions", () => {
                     result = multipleParser.parse(source);
                     switch (result.variant) {
                         case Result.Variant.Ok:
-                            expect(result.value[1]).toBe(multipleCase);
+                            expect(source.slice(result.value[1])).toBe(
+                                multipleCase,
+                            );
                             break;
 
                         case Result.Variant.Err:
@@ -342,7 +346,9 @@ describe("Individual Parser functions", () => {
                     switch (result.variant) {
                         case Result.Variant.Ok:
                             expect(result.value[0]).toBe(match);
-                            expect(result.value[1]).toBe(remaining);
+                            expect(source.slice(result.value[1])).toBe(
+                                remaining,
+                            );
                             break;
 
                         case Result.Variant.Err:
@@ -359,7 +365,9 @@ describe("Individual Parser functions", () => {
                     switch (result.variant) {
                         case Result.Variant.Ok:
                             expect(result.value[0]).toBe(Number(match));
-                            expect(result.value[1]).toBe(remaining);
+                            expect(source.slice(result.value[1])).toBe(
+                                remaining,
+                            );
                             break;
 
                         case Result.Variant.Err:
@@ -412,11 +420,12 @@ describe("Individual Parser functions", () => {
             const { int } = Parser;
 
             it("parses a number, then checks for an int", () => {
-                let result = int().parse("12345 hello");
+                const source = "12345 hello";
+                let result = int().parse(source);
                 switch (result.variant) {
                     case Result.Variant.Ok:
                         expect(result.value[0]).toBe(12345);
-                        expect(result.value[1]).toBe(" hello");
+                        expect(source.slice(result.value[1])).toBe(" hello");
                         break;
 
                     case Result.Variant.Err:
@@ -441,11 +450,14 @@ describe("Individual Parser functions", () => {
             const { integerPart } = Parser;
 
             it("greedily captures the integer part and returns a string", () => {
-                const result = integerPart().parse("123.1415 hello");
+                const source = "123.1415 hello";
+                const result = integerPart().parse(source);
                 switch (result.variant) {
                     case Result.Variant.Ok:
                         expect(result.value[0]).toBe("123");
-                        expect(result.value[1]).toBe(".1415 hello");
+                        expect(source.slice(result.value[1])).toBe(
+                            ".1415 hello",
+                        );
                         break;
 
                     case Result.Variant.Err:
@@ -459,15 +471,16 @@ describe("Individual Parser functions", () => {
         const { sequence } = Parser;
 
         it("can run a basic sequence of parsers", () => {
+            const source = "yes, and";
             const result = sequence(
                 Parser.exact("yes,"),
                 Parser.spaces(),
-            ).parse("yes, and");
+            ).parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual(["yes,", " "]);
-                    expect(result.value[1]).toBe("and");
+                    expect(source.slice(result.value[1])).toBe("and");
                     break;
 
                 case Result.Variant.Err:
@@ -519,7 +532,7 @@ describe("Individual Parser functions", () => {
                 switch (result.variant) {
                     case Result.Variant.Ok:
                         expect(result.value[0]).toEqual(matches);
-                        expect(result.value[1]).toBe(remaining);
+                        expect(source.slice(result.value[1])).toBe(remaining);
                         break;
 
                     case Result.Variant.Err:
@@ -550,7 +563,7 @@ describe("Individual Parser functions", () => {
                 switch (result.variant) {
                     case Result.Variant.Ok:
                         expect(result.value[0]).toEqual(matches);
-                        expect(result.value[1]).toBe(remaining);
+                        expect(source.slice(result.value[1])).toBe(remaining);
                         break;
 
                     case Result.Variant.Err:
@@ -597,20 +610,22 @@ describe("Individual Parser functions", () => {
         });
 
         it("acts like the underlying parser if only one parser is provided", () => {
+            let source = "abc";
             const parser = oneOf(Parser.exact("a"));
-            let result = parser.parse("abc");
+            let result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("a");
-                    expect(result.value[1]).toBe("bc");
+                    expect(source.slice(result.value[1])).toBe("bc");
                     break;
 
                 case Result.Variant.Err:
                     fail(result.error);
             }
 
-            result = parser.parse("bcd");
+            source = "bcd";
+            result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Err:
@@ -631,43 +646,47 @@ describe("Individual Parser functions", () => {
 
             const parser = oneOf(parseA, parseB, parseC);
 
-            let result = parser.parse("abc");
+            let source = "abc";
+            let result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("a");
-                    expect(result.value[1]).toBe("bc");
+                    expect(source.slice(result.value[1])).toBe("bc");
                     break;
 
                 case Result.Variant.Err:
                     fail(result.error);
             }
 
-            result = parser.parse("bca");
+            source = "bca";
+            result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("b");
-                    expect(result.value[1]).toBe("ca");
+                    expect(source.slice(result.value[1])).toBe("ca");
                     break;
 
                 case Result.Variant.Err:
                     fail(result.error);
             }
 
-            result = parser.parse("cab");
+            source = "cab";
+            result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("c");
-                    expect(result.value[1]).toBe("ab");
+                    expect(source.slice(result.value[1])).toBe("ab");
                     break;
 
                 case Result.Variant.Err:
                     fail(result.error);
             }
 
-            result = parser.parse("f");
+            source = "f";
+            result = parser.parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Err:
@@ -682,30 +701,32 @@ describe("Individual Parser functions", () => {
         });
 
         it("matches on the first parser to match", () => {
+            let source = "longer matches";
             let result = oneOf(
                 Parser.exact("longer"),
                 Parser.exact("long"),
-            ).parse("longer matches");
+            ).parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("longer");
-                    expect(result.value[1]).toBe(" matches");
+                    expect(source.slice(result.value[1])).toBe(" matches");
                     break;
 
                 case Result.Variant.Err:
                     fail(result.error);
             }
 
+            source = "shorter matches";
             result = oneOf(
                 Parser.exact("short"),
                 Parser.exact("shorter"),
-            ).parse("shorter matches");
+            ).parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("short");
-                    expect(result.value[1]).toBe("er matches");
+                    expect(source.slice(result.value[1])).toBe("er matches");
                     break;
 
                 case Result.Variant.Err:
@@ -718,14 +739,15 @@ describe("Individual Parser functions", () => {
         const { map } = Parser;
 
         it("does nothing if given identity function", () => {
+            const source = "anything";
             const result = map((x) => x, Parser.exact("anything")).parse(
-                "anything",
+                source,
             );
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual("anything");
-                    expect(result.value[1]).toBe("");
+                    expect(source.slice(result.value[1])).toBe("");
                     break;
 
                 case Result.Variant.Err:
@@ -734,10 +756,11 @@ describe("Individual Parser functions", () => {
         });
 
         it("can transform parsed values", () => {
+            const source = "anything";
             const result = map(
                 (match: string) => ({ key: "annotation", match: match }),
                 Parser.exact("anything"),
-            ).parse("anything");
+            ).parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
@@ -745,7 +768,7 @@ describe("Individual Parser functions", () => {
                         key: "annotation",
                         match: "anything",
                     });
-                    expect(result.value[1]).toBe("");
+                    expect(source.slice(result.value[1])).toBe("");
                     break;
 
                 case Result.Variant.Err:
@@ -754,6 +777,7 @@ describe("Individual Parser functions", () => {
         });
 
         it("can remove unwanted pieces of parsed values", () => {
+            const source = "123-abc";
             const result = map(
                 ([dig, , alph]) => [dig, alph],
                 Parser.sequence(
@@ -761,12 +785,12 @@ describe("Individual Parser functions", () => {
                     Parser.exact("-"),
                     Parser.alpha(),
                 ),
-            ).parse("123-abc");
+            ).parse(source);
 
             switch (result.variant) {
                 case Result.Variant.Ok:
                     expect(result.value[0]).toEqual(["123", "abc"]);
-                    expect(result.value[1]).toBe("");
+                    expect(source.slice(result.value[1])).toBe("");
                     break;
 
                 case Result.Variant.Err:

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -55,11 +55,12 @@ export namespace Parser {
             if (source.slice(index, index + toMatch.length) === toMatch) {
                 return Result.Ok([toMatch, index + toMatch.length, source]);
             }
+            const [location, context] = getErrorMessageContext(source, index);
             return Result.Err(
-                `Expected "${toMatch}" but got "${source.slice(
+                `${location}\nExpected "${toMatch}" but got "${source.slice(
                     index,
                     index + toMatch.length,
-                )}" instead`,
+                )}" instead\n\n${context}`,
             );
         });
 
@@ -191,8 +192,12 @@ export namespace Parser {
 
                 case Result.Variant.Ok:
                     if (!Number.isSafeInteger(result.value[0])) {
+                        const [location, context] = getErrorMessageContext(
+                            source,
+                            index,
+                        );
                         return Result.Err(
-                            `Expected an integer but got "${result.value[0]}" instead`,
+                            `${location}\nExpected an integer but got "${result.value[0]}" instead\n\n${context}`,
                         );
                     }
                     return result;
@@ -203,10 +208,14 @@ export namespace Parser {
         Parser<string>((source: string, index: number = 0) => {
             const match = new RegExp(`^${re.source}`).exec(source.slice(index));
             if (match === null) {
+                const [location, context] = getErrorMessageContext(
+                    source,
+                    index,
+                );
                 return Result.Err(
-                    `Expected ${expected} but got "${source.charAt(
+                    `${location}\nExpected ${expected} but got "${source.charAt(
                         index,
-                    )}" instead`,
+                    )}" instead\n\n${context}`,
                 );
             }
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -214,6 +214,53 @@ export namespace Parser {
             return Result.Ok([matched, index + matched.length, source]);
         });
 
+    function getErrorMessageContext(
+        source: string,
+        index: number,
+        maxPrevContext: number = 10,
+        maxPostContext: number = 10,
+    ): [string, string] {
+        const [line, column] = getCurrentLineAndColumn(source, index);
+        if (column > 1) {
+            maxPrevContext = Math.min(column - 1, maxPrevContext);
+        } else {
+            maxPrevContext = 0;
+        }
+        const indentation = [...Array(maxPrevContext)].fill(" ").join("");
+        return [
+            `Error at (line: ${line}, column: ${column})`,
+            `${truncateToNextNewLine(
+                source.slice(index - maxPrevContext, index + maxPostContext),
+            )}\n${indentation}^`,
+        ];
+    }
+
+    function truncateToNextNewLine(str: string): string {
+        for (let i = 1; i < str.length; i++) {
+            if (str.charAt(i) === "\n") {
+                return str.slice(0, i);
+            }
+        }
+        return str;
+    }
+
+    function getCurrentLineAndColumn(
+        source: string,
+        index: number,
+    ): [number, number] {
+        let line = 1;
+        let column = 1;
+        for (let i = 0; i < index; i++) {
+            if (source.charAt(i) === "\n") {
+                line++;
+                column = 1;
+            } else {
+                column++;
+            }
+        }
+        return [line, column];
+    }
+
     /**
      * Takes a parser and returns a parser which tries to match, using the given parser, zero or more times.
      *


### PR DESCRIPTION
Updates parsers to track how far along a parser is with an index rather than manipulating the source string directly.

Cons
Every time a new atomic combinator is implemented, the author needs to remember to pass the index or else parsing will start over halfway through.

Pros
Much clearer error messages.